### PR TITLE
ASC-1401 Utilize 'openstack-ansible' in Coverge Task

### DIFF
--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -9,67 +9,22 @@
 
 - name: Clone openstack-ansible-ops repo
   git:
-    repo=https://github.com/openstack/openstack-ansible-ops.git
-    dest=/opt/openstack-ansible-ops
-
-- name: Create python2 virtualenv for the submodule
-  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages  \
-    /opt/molecule-test-env-on-sut
-  when:
-    - rpc_product_release != "master" or
-      rpc_product_release != "rocky"
-
-- name: Create python3 virtualenv for the submodule
-  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages  \
-    --python=python3 /opt/molecule-test-env-on-sut
-  when:
-    - rpc_product_release == "master" or
-      rpc_product_release == "rocky"
-
-- name: Install pip/setuptools/wheel on the virtualenv on SUT
-  shell: |
-    . /opt/molecule-test-env-on-sut/bin/activate
-    CURL_CMD="curl --silent --show-error --retry 5"
-    OUTPUT_FILE="get-pip.py"
-    ${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > ${OUTPUT_FILE}  \
-      || ${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > ${OUTPUT_FILE}
-    GETPIP_OPTIONS="pip setuptools wheel"
-    python ${OUTPUT_FILE} ${GETPIP_OPTIONS} \
-      || python ${OUTPUT_FILE} --isolated ${GETPIP_OPTIONS}
-    deactivate
-
-- name: Install python modules into /opt/molecule-test-env-on-sut virtualenv
-  pip:
-    name: "{{ item }}"
-    extra_args: --isolated
-    state: present
-    virtualenv: /opt/molecule-test-env-on-sut
-  with_items:
-    - ansible==2.5.5
-    - shade==1.28.0
-    - ipaddr==2.2.0
-    - netaddr==0.7.19
+    repo: https://github.com/openstack/openstack-ansible-ops.git
+    dest: /opt/openstack-ansible-ops
 
 - name: Run openstack-service-setup
   shell: |
-    . /opt/molecule-test-env-on-sut/bin/activate
-    ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i "{{ inventory_file }}" openstack-service-setup.yml && deactivate
+    openstack-ansible openstack-service-setup.yml
   args:
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
   async: 2700
   poll: 60
 
-- name: create directory for ansible custom facts
-  file:
-    state: directory
-    recurse: true
-    path: /etc/ansible/facts.d
-
 - name: install custom fact for service setup
   copy:
-    content: "{\"already_ran\" : \"true\"}"
-    dest: /etc/ansible/facts.d/service_setup.fact
+    content: "{{ {'already_ran':'true'} | to_nice_json(indent=2) }}"
+    dest: "{{ custom_fact_path }}/service_setup.fact"
 
-- name: re-read facts after adding custom fact
+- name: re-read facts after adding custome fact
   setup: filter=ansible_local

--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -26,5 +26,5 @@
     content: "{{ {'already_ran':'true'} | to_nice_json(indent=2) }}"
     dest: "{{ custom_fact_path }}/service_setup.fact"
 
-- name: re-read facts after adding custome fact
+- name: re-read facts after adding custom fact
   setup: filter=ansible_local


### PR DESCRIPTION
There is a built-in alias for running the OpenStack configured version of the
Ansible client called 'openstack-ansible' which already has access to the
proper inventory. Update the 'os_service_setup' converge task to use the
'openstack-ansible' client instead of creating a custom Ansible environment.

Supersedes [#165](https://github.com/rcbops/molecule-rpc-openstack-post-deploy/pull/165). 