### PR TITLE
Revert "ASC-1401 Utilize 'openstack-ansible' in Coverge Task"

### DIFF
--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -9,22 +9,67 @@
 
 - name: Clone openstack-ansible-ops repo
   git:
-    repo: https://github.com/openstack/openstack-ansible-ops.git
-    dest: /opt/openstack-ansible-ops
+    repo=https://github.com/openstack/openstack-ansible-ops.git
+    dest=/opt/openstack-ansible-ops
+
+- name: Create python2 virtualenv for the submodule
+  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages  \
+    /opt/molecule-test-env-on-sut
+  when:
+    - rpc_product_release != "master" or
+      rpc_product_release != "rocky"
+
+- name: Create python3 virtualenv for the submodule
+  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages  \
+    --python=python3 /opt/molecule-test-env-on-sut
+  when:
+    - rpc_product_release == "master" or
+      rpc_product_release == "rocky"
+
+- name: Install pip/setuptools/wheel on the virtualenv on SUT
+  shell: |
+    . /opt/molecule-test-env-on-sut/bin/activate
+    CURL_CMD="curl --silent --show-error --retry 5"
+    OUTPUT_FILE="get-pip.py"
+    ${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > ${OUTPUT_FILE}  \
+      || ${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > ${OUTPUT_FILE}
+    GETPIP_OPTIONS="pip setuptools wheel"
+    python ${OUTPUT_FILE} ${GETPIP_OPTIONS} \
+      || python ${OUTPUT_FILE} --isolated ${GETPIP_OPTIONS}
+    deactivate
+
+- name: Install python modules into /opt/molecule-test-env-on-sut virtualenv
+  pip:
+    name: "{{ item }}"
+    extra_args: --isolated
+    state: present
+    virtualenv: /opt/molecule-test-env-on-sut
+  with_items:
+    - ansible==2.5.5
+    - shade==1.28.0
+    - ipaddr==2.2.0
+    - netaddr==0.7.19
 
 - name: Run openstack-service-setup
   shell: |
-    openstack-ansible openstack-service-setup.yml
+    . /opt/molecule-test-env-on-sut/bin/activate
+    ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i "{{ inventory_file }}" openstack-service-setup.yml && deactivate
   args:
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
   async: 2700
   poll: 60
 
+- name: create directory for ansible custom facts
+  file:
+    state: directory
+    recurse: true
+    path: /etc/ansible/facts.d
+
 - name: install custom fact for service setup
   copy:
-    content: "{{ {'already_ran':'true'} | to_nice_json(indent=2) }}"
-    dest: "{{ custom_fact_path }}/service_setup.fact"
+    content: "{\"already_ran\" : \"true\"}"
+    dest: /etc/ansible/facts.d/service_setup.fact
 
 - name: re-read facts after adding custom fact
   setup: filter=ansible_local


### PR DESCRIPTION
Well apparently this is just not going to happen. I cannot get this change to work on Pike and below. Reverting to the old method because it actually works!